### PR TITLE
iOS9 universal links 지원에 따른 custom scheme의 fallback 처리

### DIFF
--- a/lib/web2app.js
+++ b/lib/web2app.js
@@ -90,7 +90,13 @@
                 }
                 bindVisibilityChangeEvent(tid);
             }
-            launchAppViaHiddenIframe(urlScheme);
+
+            // https://developer.apple.com/library/prerelease/ios/documentation/General/Conceptual/AppSearch/UniversalLinks.html#//apple_ref/doc/uid/TP40016308-CH12
+            if ( isSupportUniversalLinks() ){
+                launchAppViaChangingLocation(urlScheme);
+            }else{
+                launchAppViaHiddenIframe(urlScheme);
+            }
         }
 
         function bindPagehideEvent (tid) {
@@ -121,6 +127,10 @@
             return true;
         }
 
+        function launchAppViaChangingLocation (urlScheme){
+            window.top.location.href = urlScheme;
+        }
+
         function launchAppViaHiddenIframe (urlScheme) {
             setTimeout(function () {
                 var iframe = createHiddenIframe('appLauncher');
@@ -138,6 +148,10 @@
             iframe.style.overflow = 'hidden';
             document.body.appendChild(iframe);
             return iframe;
+        }
+
+        function isSupportUniversalLinks(){
+            return (parseInt(ua.os.version.major, 10) > 8 && ua.os.ios)
         }
 
         /**


### PR DESCRIPTION
iOS9 부터 universal links 이슈에 따라 hidden iframe로 custom scheme 호출할 수 없음. location.href 에 custom scheme 을 set 하는 방식은 동작함.
universal links 을 정식으로 지원하는 것은 조금 상황을 봐야 할 듯 하고 그 전에 iOS9에서 custome scheme이 동작하도록 fallback 만 추가.

* univeral links 에 대한 참고문서 
https://developer.apple.com/library/prerelease/ios/documentation/General/Conceptual/AppSearch/UniversalLinks.html