### PR TITLE
iOS9 에서 앱이 설치 되어 있음에도 무조건 스토어로 이동하는 버그 수정

### DIFF
--- a/lib/web2app.js
+++ b/lib/web2app.js
@@ -93,6 +93,7 @@
 
             // https://developer.apple.com/library/prerelease/ios/documentation/General/Conceptual/AppSearch/UniversalLinks.html#//apple_ref/doc/uid/TP40016308-CH12
             if ( isSupportUniversalLinks() ){
+                clearTimeout(tid);
                 launchAppViaChangingLocation(urlScheme);
             }else{
                 launchAppViaHiddenIframe(urlScheme);


### PR DESCRIPTION
일정시간 후에 페이지에 변화가 없으면 스토어로 이동하는 방식인데 iOS9에서는 사용자에게 confirm 창으로 앱이동을 확인받는다. 그래서 생기는 버그.
스토어로 이동하는 타이머를 일단 제거. 앱이 없더라도 스토어로 이동하지 못하지만 앱이 실행되지 않는게 더 크리티컬하다고 판단됨.