### PR TITLE
universalLink 추가 및 선물하기 샘플페이지 추가

### DIFF
--- a/lib/web2app.js
+++ b/lib/web2app.js
@@ -33,7 +33,7 @@
                     web2appViaCustomUrlSchemeForAndroid(context.urlScheme, context.storeURL, onAppMissing);
                 }
             } else if (os.ios && context.storeURL) {
-                web2appViaCustomUrlSchemeForIOS(context.urlScheme, context.storeURL, onAppMissing);
+                web2appViaCustomUrlSchemeForIOS(context.urlScheme, context.storeURL, onAppMissing, context.universalLink);
             } else {
                 setTimeout(function () {
                     onUnsupportedEnvironment();
@@ -75,7 +75,7 @@
             }
         }
 
-        function web2appViaCustomUrlSchemeForIOS (urlScheme, storeURL, fallback) {
+        function web2appViaCustomUrlSchemeForIOS (urlScheme, storeURL, fallback, universalLink) {
             var tid = deferFallback(TIMEOUT_IOS, storeURL, fallback);
             if (parseInt(ua.os.version.major, 10) < 8) {
                 bindPagehideEvent(tid);
@@ -86,7 +86,9 @@
             // https://developer.apple.com/library/prerelease/ios/documentation/General/Conceptual/AppSearch/UniversalLinks.html#//apple_ref/doc/uid/TP40016308-CH12
             if ( isSupportUniversalLinks() ){
                 clearTimeout(tid);
-                launchAppViaChangingLocation(urlScheme);
+		            if (universalLink === undefined)
+		                universalLink = urlScheme;
+                launchAppViaChangingLocation(universalLink);
             }else{
                 launchAppViaHiddenIframe(urlScheme);
             }

--- a/samples/test.html
+++ b/samples/test.html
@@ -39,6 +39,12 @@
 			<br/><br/><br/><br/>
 		</div>
 
+		<h3 class="tit_index">카카오톡 선물하기 web2app</h3>
+		<div class="box_guide" >
+			<button id="web2appTestBtn4">선물하기 이동 버튼</button>
+			<br/><br/><br/><br/>
+		</div>
+		
 		<br/><br/><br/>
 
 		<div id="logContainer"></div>
@@ -127,6 +133,30 @@
 				});
 			}
 		});
+		
+		// 선물하기 universalLink 적용
+	var	btnEl4 = document.getElementById('web2appTestBtn4'),
+		scheme4 = 'storylink',
+		pkgName4 = 'com.kakao.story',
+		universalLink4 = 'https://talk-apps.kakao.com/scheme/kakaotalk%3A%2F%2Fgift%2Fhome',
+		urlScheme4 = 'kakaotalk://gift/home',
+		intentURI4 = 'intent://gift/home',
+		appStoreURL4 = ua.os.android ? 'market://details?id=' + pkgName4 : 'itms-apps://itunes.apple.com/app/id362057947';
+
+	btnEl4.addEventListener('click', function () {
+		if (ua.platform === 'pc') {
+			alert('모바일 기기에서 이용 가능한 기능입니다.\r\n카카오톡이 설치된 스마트폰에서 이용해 주세요.');
+		} else {
+			daumtools.web2app({
+				urlScheme : urlScheme4,
+				intentURI : intentURI4,
+				storeURL : appStoreURL4,
+				universalLink : universalLink4,
+				appName : '카카오선물하기'
+			});
+		}
+	});
+			
 	})();
 </script>
 </body>


### PR DESCRIPTION
<이슈>
iOS9.1이상에서 페이스북 웹뷰에서 카카오톡 앱으로 넘어오는 링크가 정상적으로 동작하지 않습니다.

<원인>
페이스북에서 보안정책(app transport security)에 따라 universalLink로 보내지 않으면 앱스토어 다운로드 페이지로 이동하고 있습니다.

<수정사항>
web2appViaCustomUrlSchemeForIOS에 universalLink URL을 파라미터로 추가하고
universalLink가 필요한 iOS인 경우 해당 링크로 앱 열 수 있도록 수정하였습니다.

검토 후 적용 부탁드립니다. ^^

감사합니다.
